### PR TITLE
- sets minimal version to 3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: 'latest'
           cache-version: 1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['2.7', '3.0', '3.1', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby-version: ['3.0', '3.1', '3.2', head, jruby, jruby-head, truffleruby, truffleruby-head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         run: bundle exec rake
       - name: Upload artifacts for ruby version 3 and ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest'  && matrix.ruby-version == '3.1'}}
+        if: ${{ matrix.os == 'ubuntu-latest'  && matrix.ruby-version == '3.2'}}
         uses: actions/upload-artifact@v3
         with:
           name: drop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped minimum required ruby version to 3.0.
+
 ## [0.13.0] - 2023-01-10
 
 ### Added

--- a/microsoft_kiota_abstractions.gemspec
+++ b/microsoft_kiota_abstractions.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'microsoft_kiota_abstractions'
   spec.version       = MicrosoftKiotaAbstractions::VERSION
   spec.authors       = 'Microsoft Corporation'
-  spec.email         = 'graphsdkpub@microsoft.com'
+  spec.email         = 'graphsdkpub+ruby@microsoft.com'
   spec.description   = 'Microsoft Kiota Abstractions - Ruby abstractions for building library agnostic http client'
   spec.summary       = 'The Kiota abstractions are language specific libraries defining the basic constructs Kiota projects need once an SDK has been generated from an OpenAPI definition.'
   spec.homepage      = 'https://microsoft.github.io/kiota/'
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/microsoft/kiota-abstractions-ruby',
     'github_repo'     => 'ssh://github.com/microsoft/kiota-abstractions-ruby'
   }
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
EOL of 2.7 is less than 2 months, and we're not staffed to GA before that, https://endoflife.date/ruby https://azure.microsoft.com/en-us/updates/rubysupport