### PR TITLE
Fix error logging for invalid content types 

### DIFF
--- a/lib/microsoft_kiota_abstractions/serialization/parse_node_factory_registry.rb
+++ b/lib/microsoft_kiota_abstractions/serialization/parse_node_factory_registry.rb
@@ -35,7 +35,7 @@ module MicrosoftKiotaAbstractions
       if factory
         return factory.get_parse_node(clean_content_type, content)
       end
-      raise Exception.new "Content type #{contentType} does not have a factory to be parsed"
+      raise Exception.new "Content type #{content_type} does not have a factory to be parsed"
     end
         
   end


### PR DESCRIPTION
`contentType` does not exist, the correct variable is `content_type`.