### PR TITLE
fix setting the content in request information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.14.4] - 2024-01-06
+
+### Changed
+
+- Fixed a bug that was causing the content not to be set in the request information.
+
 ## [0.14.3] - 2023-10-11
 
 ### Added

--- a/lib/microsoft_kiota_abstractions/request_information.rb
+++ b/lib/microsoft_kiota_abstractions/request_information.rb
@@ -100,7 +100,7 @@ module MicrosoftKiotaAbstractions
         else
           writer.write_object_value(nil, values);
         end
-        this.content = writer.get_serialized_content();
+        @content = writer.get_serialized_content();
       rescue => exception
         raise Exception.new "could not serialize payload"
       end

--- a/lib/microsoft_kiota_abstractions/version.rb
+++ b/lib/microsoft_kiota_abstractions/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MicrosoftKiotaAbstractions
-  VERSION = "0.14.3"
+  VERSION = "0.14.4"
 end


### PR DESCRIPTION
I was getting
`Exception: could not serialize payload...Caused by NameError: undefined local variable or method `this' for #<MicrosoftKiotaAbstractions::RequestInformation...`

Now it works as expected

fixes #32