### PR TITLE
Fix json serialization in set_content_from_parsable

### DIFF
--- a/lib/microsoft_kiota_abstractions/request_information.rb
+++ b/lib/microsoft_kiota_abstractions/request_information.rb
@@ -96,9 +96,9 @@ module MicrosoftKiotaAbstractions
         writer  = request_adapter.get_serialization_writer_factory().get_serialization_writer(content_type)
         @headers.try_add(@@content_type_header, content_type)
         if values != nil && values.kind_of?(Array)
-          writer.write_collection_of_object_values(nil, values)
+          writer = writer.write_collection_of_object_values(nil, values)
         else
-          writer.write_object_value(nil, values);
+          writer = writer.write_object_value(nil, values);
         end
         @content = writer.get_serialized_content();
       rescue => exception


### PR DESCRIPTION
When the key is nil, `writer.write_object_value` returns a new hash. So, `@content = writer.get_serialized_content();` is always `{}` as the writer is not modified.

Here's the code that generate the new dictioray when the key is nil in 

https://github.com/microsoft/kiota-serialization-json-ruby/blob/1f9ffe3df487684f9fee09dbcb47954c38db0428/lib/microsoft_kiota_serialization_json/json_serialization_writer.rb#L160-L175

```ruby
def write_object_value(key, value)
  if value
    if !key
      temp = JsonSerializationWriter.new()
      value.serialize(temp)
      return temp
    end
    begin
      temp = JsonSerializationWriter.new()
      value.serialize(temp)
      @writer[key] = temp.writer
    rescue StandardError => e
      raise e.class, "no key or value included in write_boolean_value(key, value)" 
    end
  end
end
```

I'm not a ruby expert. In fact, it the first time I have to deal with ruby. So, I'm not sure this is the right fix.