### PR TITLE
AnonymousAuthenticationProvider.authenticate_request returns an empty Fiber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- AnonymousAuthenticationProvider.authenticate_request returns an empty Fiber to align with other AuthenticationProvider.
+
 ## [0.14.4] - 2024-01-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- AnonymousAuthenticationProvider.authenticate_request returns an empty Fiber to align with other AuthenticationProvider.
-
 ## [0.14.4] - 2024-01-06
 
 ### Changed

--- a/lib/microsoft_kiota_abstractions/authentication/anonymous_authentication_provider.rb
+++ b/lib/microsoft_kiota_abstractions/authentication/anonymous_authentication_provider.rb
@@ -2,6 +2,9 @@ module MicrosoftKiotaAbstractions
   class AnonymousAuthenticationProvider
     include MicrosoftKiotaAbstractions::AuthenticationProvider
     def authenticate_request(request)
+      # return an empty Fiber - all other authentication providers do the same, and the FaradayRequestAdapter requires it.
+      Fiber.new do
+      end
     end
   end
 end

--- a/lib/microsoft_kiota_abstractions/authentication/anonymous_authentication_provider.rb
+++ b/lib/microsoft_kiota_abstractions/authentication/anonymous_authentication_provider.rb
@@ -1,7 +1,7 @@
 module MicrosoftKiotaAbstractions
   class AnonymousAuthenticationProvider
     include MicrosoftKiotaAbstractions::AuthenticationProvider
-    def authenticate_request(request)
+    def authenticate_request(request, additional_properties = {})
       # return an empty Fiber - all other authentication providers do the same, and the FaradayRequestAdapter requires it.
       Fiber.new do
       end

--- a/lib/microsoft_kiota_abstractions/authentication/base_bearer_token_authentication_provider.rb
+++ b/lib/microsoft_kiota_abstractions/authentication/base_bearer_token_authentication_provider.rb
@@ -17,10 +17,16 @@ module MicrosoftKiotaAbstractions
     def authenticate_request(request, additional_properties = {})
       raise StandardError, 'Request cannot be null' if request.nil?
 
-      Fiber.new do
-        token = @access_token_provider.get_authorization_token(request.uri, additional_properties).resume
-        request.headers.add(AUTHORIZATION_HEADER_KEY, "Bearer #{token}") unless token.nil? || token.empty?
-      end unless request.headers.get_all.key?(AUTHORIZATION_HEADER_KEY)
+      # If request contains already an authorization header, nothing needs to be done.
+      if request.headers.get_all.key?(AUTHORIZATION_HEADER_KEY)
+        Fiber.new do
+        end
+      else
+        Fiber.new do
+          token = @access_token_provider.get_authorization_token(request.uri, additional_properties).resume
+          request.headers.add(AUTHORIZATION_HEADER_KEY, "Bearer #{token}") unless token.nil? || token.empty?
+        end
+      end
     end
   end
 end

--- a/spec/access_token_provider_mock.rb
+++ b/spec/access_token_provider_mock.rb
@@ -1,0 +1,11 @@
+require 'microsoft_kiota_abstractions'
+
+class AccessTokenProviderMock
+  extend MicrosoftKiotaAbstractions::AccessTokenProvider
+  
+    def get_authorization_token(uri, additional_properties = {})
+      Fiber.new do        
+        "DUMMY_TOKEN"
+      end
+    end
+end

--- a/spec/access_token_provider_mock.rb
+++ b/spec/access_token_provider_mock.rb
@@ -3,9 +3,10 @@ require 'microsoft_kiota_abstractions'
 class AccessTokenProviderMock
   extend MicrosoftKiotaAbstractions::AccessTokenProvider
   
+    DUMMY_TOKEN = 'DummyToken'
     def get_authorization_token(uri, additional_properties = {})
       Fiber.new do        
-        "DUMMY_TOKEN"
+        DUMMY_TOKEN
       end
     end
 end

--- a/spec/microsoft_kiota_abstractions_spec.rb
+++ b/spec/microsoft_kiota_abstractions_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'uri'
 require 'microsoft_kiota_abstractions'
-
+require_relative 'access_token_provider_mock'
 
 RSpec.describe MicrosoftKiotaAbstractions do
   it "has a version number" do
@@ -18,6 +18,30 @@ RSpec.describe MicrosoftKiotaAbstractions do
     expect(token_provider).not_to be nil
     # Authentication does nothing besides returning an empty Fiber
     token_provider.authenticate_request(nil).resume
+  end
+
+  it "creates a token authentication provider with existing authorization header" do
+    access_token_provider = AccessTokenProviderMock.new()
+    token_provider = MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider.new(access_token_provider)
+    expect(token_provider).not_to be nil
+    request_obj = MicrosoftKiotaAbstractions::RequestInformation.new
+    request_obj.headers.add(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY, "SAMPLE")
+    # Authentication does nothing besides returning an empty Fiber
+    token_provider.authenticate_request(request_obj).resume
+    # The request header should be unchanged
+    expect(request_obj.headers.get(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY).at(0)).to eq "SAMPLE"
+  end
+
+  it "creates a token authentication provider without authorization header, which should fail" do
+    access_token_provider = AccessTokenProviderMock.new()
+    token_provider = MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider.new(access_token_provider)
+    expect(token_provider).not_to be nil
+    request_obj = MicrosoftKiotaAbstractions::RequestInformation.new
+    # We have to set a URI, otherwise the code will fail ("undefined method 'chars' for nil")
+    request_obj.uri = "http://sample.com"
+    token_provider.authenticate_request(request_obj).resume
+    # The request header should now contain the "DUMMY_TOKEN" value:
+    expect(request_obj.headers.get(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY).at(0)).to eq "Bearer DUMMY_TOKEN"
   end
 
   it "returns the raw URI when set via setter" do

--- a/spec/microsoft_kiota_abstractions_spec.rb
+++ b/spec/microsoft_kiota_abstractions_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe MicrosoftKiotaAbstractions do
     request_obj.headers.add(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY, "SAMPLE")
     # Authentication does nothing besides returning an empty Fiber
     token_provider.authenticate_request(request_obj).resume
-    # The request header should be unchanged
+    # The request header should not have changed
     expect(request_obj.headers.get(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY).at(0)).to eq "SAMPLE"
   end
 
-  it "creates a token authentication provider without authorization header, which should fail" do
+  it "creates a token authentication provider with mock access token" do
     access_token_provider = AccessTokenProviderMock.new()
     token_provider = MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider.new(access_token_provider)
     expect(token_provider).not_to be nil
@@ -41,7 +41,7 @@ RSpec.describe MicrosoftKiotaAbstractions do
     request_obj.uri = "http://sample.com"
     token_provider.authenticate_request(request_obj).resume
     # The request header should now contain the "DUMMY_TOKEN" value:
-    expect(request_obj.headers.get(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY).at(0)).to eq "Bearer DUMMY_TOKEN"
+    expect(request_obj.headers.get(MicrosoftKiotaAbstractions::BaseBearerTokenAuthenticationProvider::AUTHORIZATION_HEADER_KEY).at(0)).to eq "Bearer #{AccessTokenProviderMock::DUMMY_TOKEN}"
   end
 
   it "returns the raw URI when set via setter" do

--- a/spec/microsoft_kiota_abstractions_spec.rb
+++ b/spec/microsoft_kiota_abstractions_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe MicrosoftKiotaAbstractions do
   it "creates a anonymous token provider" do
     token_provider = MicrosoftKiotaAbstractions::AnonymousAuthenticationProvider.new()
     expect(token_provider).not_to be nil
+    # Authentication does nothing besides returning an empty Fiber
+    token_provider.authenticate_request(nil).resume
   end
 
   it "returns the raw URI when set via setter" do


### PR DESCRIPTION
This fixes #82 

The [FaradayRequestAdapter](https://github.com/microsoft/kiota-http-ruby/blob/main/lib/microsoft_kiota_faraday/faraday_request_adapter.rb) calls `resume` on the `AuthenticationProvider.authenticate_request` method. This fails for the `AnonymousAuthenticationProvider`.