### PR TITLE
feat: add composed types support (union/intersection)

### DIFF
--- a/lib/microsoft_kiota_abstractions.rb
+++ b/lib/microsoft_kiota_abstractions.rb
@@ -22,6 +22,8 @@ require_relative "microsoft_kiota_abstractions/serialization/parse_node_factory_
 require_relative "microsoft_kiota_abstractions/serialization/serialization_writer"
 require_relative "microsoft_kiota_abstractions/serialization/serialization_writer_factory"
 require_relative "microsoft_kiota_abstractions/serialization/serialization_writer_factory_registry"
+require_relative "microsoft_kiota_abstractions/serialization/composed_type_wrapper"
+require_relative "microsoft_kiota_abstractions/serialization/parse_node_helper"
 
 module MicrosoftKiotaAbstractions
 end

--- a/lib/microsoft_kiota_abstractions/serialization/composed_type_wrapper.rb
+++ b/lib/microsoft_kiota_abstractions/serialization/composed_type_wrapper.rb
@@ -1,0 +1,4 @@
+module MicrosoftKiotaAbstractions
+  module ComposedTypeWrapper
+  end
+end

--- a/lib/microsoft_kiota_abstractions/serialization/parse_node_helper.rb
+++ b/lib/microsoft_kiota_abstractions/serialization/parse_node_helper.rb
@@ -1,0 +1,11 @@
+module MicrosoftKiotaAbstractions
+  class ParseNodeHelper
+    def self.merge_deserializers_for_intersection_wrapper(*targets)
+      result = {}
+      targets.each do |target|
+        result.merge!(target.get_field_deserializers) unless target.nil?
+      end
+      result
+    end
+  end
+end

--- a/lib/microsoft_kiota_abstractions/serialization/serialization_writer.rb
+++ b/lib/microsoft_kiota_abstractions/serialization/serialization_writer.rb
@@ -64,6 +64,10 @@ module MicrosoftKiotaAbstractions
     def write_any_value(key, value)
       raise NotImplementedError.new
     end
-    
+
+    def write_object_value(key, value, *additional_values_to_merge)
+      raise NotImplementedError.new
+    end
+
   end
 end

--- a/spec/parse_node_helper_spec.rb
+++ b/spec/parse_node_helper_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'microsoft_kiota_abstractions'
+
+RSpec.describe MicrosoftKiotaAbstractions::ComposedTypeWrapper do
+  it 'can be included in a class as a marker module' do
+    klass = Class.new { include MicrosoftKiotaAbstractions::ComposedTypeWrapper }
+    instance = klass.new
+    expect(instance).to be_a(MicrosoftKiotaAbstractions::ComposedTypeWrapper)
+  end
+
+  it 'is not present on classes that do not include it' do
+    klass = Class.new
+    instance = klass.new
+    expect(instance).not_to be_a(MicrosoftKiotaAbstractions::ComposedTypeWrapper)
+  end
+end
+
+RSpec.describe MicrosoftKiotaAbstractions::SerializationWriter do
+  let(:writer_class) { Class.new { include MicrosoftKiotaAbstractions::SerializationWriter } }
+
+  it 'raises NotImplementedError for write_object_value' do
+    writer = writer_class.new
+    expect { writer.write_object_value('key', Object.new) }.to raise_error(NotImplementedError)
+  end
+
+  it 'accepts variadic additional_values_to_merge in its signature' do
+    writer = writer_class.new
+    expect { writer.write_object_value('key', Object.new, Object.new, Object.new) }.to raise_error(NotImplementedError)
+  end
+end
+
+RSpec.describe MicrosoftKiotaAbstractions::ParseNodeHelper do
+  describe '.merge_deserializers_for_intersection_wrapper' do
+    it 'returns an empty hash when no targets are provided' do
+      result = described_class.merge_deserializers_for_intersection_wrapper
+      expect(result).to eq({})
+    end
+
+    it 'skips nil targets' do
+      result = described_class.merge_deserializers_for_intersection_wrapper(nil, nil)
+      expect(result).to eq({})
+    end
+
+    it 'merges deserializers from a single target' do
+      target = double('Parsable')
+      allow(target).to receive(:get_field_deserializers).and_return({ 'name' => :name_handler, 'age' => :age_handler })
+
+      result = described_class.merge_deserializers_for_intersection_wrapper(target)
+      expect(result).to eq({ 'name' => :name_handler, 'age' => :age_handler })
+    end
+
+    it 'merges deserializers from multiple targets' do
+      target1 = double('Parsable1')
+      target2 = double('Parsable2')
+      allow(target1).to receive(:get_field_deserializers).and_return({ 'name' => :name_handler })
+      allow(target2).to receive(:get_field_deserializers).and_return({ 'email' => :email_handler })
+
+      result = described_class.merge_deserializers_for_intersection_wrapper(target1, target2)
+      expect(result).to eq({ 'name' => :name_handler, 'email' => :email_handler })
+    end
+
+    it 'later targets override earlier targets on key conflict' do
+      target1 = double('Parsable1')
+      target2 = double('Parsable2')
+      allow(target1).to receive(:get_field_deserializers).and_return({ 'name' => :handler_v1 })
+      allow(target2).to receive(:get_field_deserializers).and_return({ 'name' => :handler_v2 })
+
+      result = described_class.merge_deserializers_for_intersection_wrapper(target1, target2)
+      expect(result).to eq({ 'name' => :handler_v2 })
+    end
+
+    it 'skips nil targets mixed with valid targets' do
+      target = double('Parsable')
+      allow(target).to receive(:get_field_deserializers).and_return({ 'id' => :id_handler })
+
+      result = described_class.merge_deserializers_for_intersection_wrapper(nil, target, nil)
+      expect(result).to eq({ 'id' => :id_handler })
+    end
+  end
+end


### PR DESCRIPTION
Add infrastructure needed for the Kiota generator to emit composed type code for union and intersection types:

- Add write_object_value to SerializationWriter interface with variadic additional_values_to_merge parameter
- Add ComposedTypeWrapper marker module for generated wrapper classes
- Add ParseNodeHelper.merge_deserializers_for_intersection_wrapper for merging field deserializers across intersection type members